### PR TITLE
PTV-1685 Fix repeated output lines bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,11 @@ A [KBase](https://kbase.us) module using the [KBase SDK](https://github.com/kbas
 
 This project uses Jinja2 for templating html/css. You can install pip dependencies locally with pipenv and the Pipfile
 
+## kb-sdk test
+
+Note that `kb-sdk test` must be run against the CI environment, which has a hard coded
+public workspace containing test data.
+
 ## Manual tests
 
 I have some manual unit tests that bypass the kb-sdk workflow to support TDD. To get these to run:

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,16 @@
 # FastANI release notes
 =========================================
 
+0.1.3
+-----
+* Fixed a bug where assembly filenames with non-unique parts before the first `.` would
+  result in repeated identical output lines
+
+
+0.1.2 and below
+---------------
+* No release notes were recorded
+
 0.0.0
 -----
 * Module created by kb-sdk init

--- a/kbase.yml
+++ b/kbase.yml
@@ -8,7 +8,7 @@ service-language:
     python
 
 module-version:
-    0.1.2
+    0.1.3
 
 owners:
     [jayrbolton]

--- a/lib/FastANI/FastANIImpl.py
+++ b/lib/FastANI/FastANIImpl.py
@@ -66,7 +66,7 @@ class FastANI:
         # Download the data
         paths = download_fasta(params['refs'], self.callback_url)
         output_paths = run_fast_ani_pairwise(self.shared_folder, paths)
-        result_data = get_result_data(output_paths)
+        result_data = get_result_data(output_paths, debug=True)
         results = create_report(self.callback_url, self.shared_folder, ws_name, result_data)
         #END fast_ani
 

--- a/lib/FastANI/FastANIImpl.py
+++ b/lib/FastANI/FastANIImpl.py
@@ -66,7 +66,7 @@ class FastANI:
         # Download the data
         paths = download_fasta(params['refs'], self.callback_url)
         output_paths = run_fast_ani_pairwise(self.shared_folder, paths)
-        result_data = get_result_data(output_paths, debug=True)
+        result_data = get_result_data(output_paths, debug=False)
         results = create_report(self.callback_url, self.shared_folder, ws_name, result_data)
         #END fast_ani
 

--- a/lib/FastANI/utils/downloader.py
+++ b/lib/FastANI/utils/downloader.py
@@ -18,12 +18,16 @@ def download_fasta(refs, cb_url):
     paths = []
     for (obj, ref) in zip(ws_objects['data'], refs):
         ws_type = obj['info'][2]
+        # This should be handled by AssemblyUtil, don't make the user do it
         if 'KBaseGenomes.Genome' in ws_type:
             assembly_ref = get_assembly_ref_from_genome(ref, obj)
         elif 'KBaseGenomeAnnotations.Assembly' in ws_type:
             assembly_ref = ref
         else:
             raise TypeError('Invalid type ' + ws_type + '. Must be an Assembly or Genome.')
+        # Sooo what happens if the path for two different assemblies is the same?
+        # AssemblyUtil seems to get a name from somewhere, and it's not a UUID or anything
+        # that's guaranteed to be unique
         path = assembly_util.get_assembly_as_fasta({'ref': assembly_ref})['path']
         paths.append(path)
     return paths

--- a/lib/FastANI/utils/fast_ani_output.py
+++ b/lib/FastANI/utils/fast_ani_output.py
@@ -10,7 +10,7 @@ env = Environment(
 # Construct some pretty-ish output for FastANI
 
 
-def get_result_data(output_paths):
+def get_result_data(output_paths, debug=False):
     """
     Create a list of objects of all the result data from running fastani
     """
@@ -29,6 +29,9 @@ def get_result_data(output_paths):
                     'viz_path': path + '.visual.pdf',
                     'viz_filename': os.path.basename(path) + '.visual.pdf'
                 })
+                if debug:
+                    print("=" * 8  + " " + path + " " + "=" * 8)
+                    print(result_data[-1])
             else:
                 print(('Invalid results from fastANI: ' + contents))
     result_data = sorted(result_data, key=lambda r: float(r['percentage_match']))

--- a/lib/FastANI/utils/fast_ani_proc.py
+++ b/lib/FastANI/utils/fast_ani_proc.py
@@ -36,8 +36,7 @@ def _run_proc(scratch, path1, path2):
     :param path2: path for the reference genome file
     :returns: output file path
     """
-    def basename(path): return os.path.basename(path).split('.')[0]
-    out_name = basename(path1) + '-' + basename(path2) + '.out'
+    out_name = os.path.basename(path1) + '-' + os.path.basename(path2) + '.out'
     out_path = os.path.join(scratch, out_name)
     args = ['fastANI', '-q', path1, '-r', path2, '--visualize', '-o', out_path, '--threads', '2']
     try:

--- a/test/test_fast_ani.py
+++ b/test/test_fast_ani.py
@@ -23,8 +23,8 @@ class TestFastANI(unittest.TestCase):
         tmp_dir = tempfile.mkdtemp()
         out_paths = run_fast_ani_pairwise(tmp_dir, [path1, path2])
         self.assertEqual(set(out_paths), set([
-            os.path.join(tmp_dir, 'ecoli-shigella.out'),
-            os.path.join(tmp_dir, 'shigella-ecoli.out')
+            os.path.join(tmp_dir, 'ecoli.fna-shigella.fna.out'),
+            os.path.join(tmp_dir, 'shigella.fna-ecoli.fna.out')
         ]))
         result_data = get_result_data(out_paths)
         print('result_data:', result_data)


### PR DESCRIPTION
When creating an output file name for a FastANI paired run, the code trims off everything after the first `.` for the two input files and hyphens them together. When the filenames prior to the `.` aren't unique, this causes the output file to be overwritten, potentially repeatedly, and the output to be wrong.