### PR TITLE
PTV-1685: Add a note about missing results

### DIFF
--- a/lib/FastANI/utils/templates/result_tables.html
+++ b/lib/FastANI/utils/templates/result_tables.html
@@ -15,6 +15,8 @@
 <body>
   <h1 class='f2'> FastANI Results </h1>
   <p> Successfully queried every assembly. Results are sorted by ANI Match, with the highest match at the bottom. </p>
+  <p> Note: No ANI output is reported for a genome pair if the ANI value is much below 80%.
+      See the documentation for more information.</p>
 
   <table class='collapse ba br2 b--black-10 pv2 ph3'>
     <thead><tr>


### PR DESCRIPTION
Confusing for users when FastANI drops results - point them to the documentation.

![image](https://user-images.githubusercontent.com/1686141/128902703-e03bdd0f-9e6c-4a6f-86ba-6f3591c43fd1.png)
